### PR TITLE
Fix examples

### DIFF
--- a/examples/l0-basic-without-hadoop/ex0-wordcount/driver.py
+++ b/examples/l0-basic-without-hadoop/ex0-wordcount/driver.py
@@ -8,7 +8,9 @@ import hadoopy
 import os
 
 # Setup paths
-input_path = os.path.abspath('../../data/wc-input-alice.txt')
+here = os.path.abspath(os.path.dirname(__file__))
+input_path = os.path.join(here, '..', '..', 'data', 'wc-input-alice.txt')
+wc_py = os.path.join(here, 'wc.py')
 
 # Read input as an iterator of (line_num, line).  'line_num' is the key
 # and line is the value; however, in wc.py only the value is used.  Notice that
@@ -45,7 +47,7 @@ def get_lines(fn):
 # form they are provided.  All base types are serialized very efficiently and they fall back to Pickle
 # for types not supported by TypedBytes.  If this is confusing, just know that you can input/output
 # anything you can pickle and Hadoopy does things in a fast way.
-output_kvs = hadoopy.launch_local(get_lines(input_path), None, 'wc.py')['output']
+output_kvs = hadoopy.launch_local(get_lines(input_path), None, wc_py )['output']
 
 # Analyze the output.  The output is an iterator of (word, count) where word is a string and count
 # is an integer.

--- a/examples/l1-basic-with-hadoop/ex0-wordcount/driver.py
+++ b/examples/l1-basic-with-hadoop/ex0-wordcount/driver.py
@@ -1,13 +1,16 @@
 import hadoopy
 import time
+import os
 
 # Setup paths
+here = os.path.abspath(os.path.dirname(__file__))
 data_path = 'hadoopy-test-data/%f/' % time.time()
 input_path = data_path + 'wc-input-alice.tb'
 output_path = data_path + 'wc-output-alice'
 
 # Put the data from a local path onto HDFS
-hadoopy.put('../../data/wc-input-alice.tb', input_path)
+
+hadoopy.put(os.path.join(here, '..', '..', 'data' ,'wc-input-alice.tb'), input_path)
 
 # Launch the job.  The wc.py script will be "frozen" (all dependencies are discovered using Pyinstaller).
 # The cluster doesn't need Hadoopy, Python, or any other libraries for this to work (as long as Pyinstaller can find everything, if not there are simple things that you can do to fix it).


### PR DESCRIPTION
Paths to data and scripts is absolute, so it's possible to run examples as::
  python examples/l1-basic-with-hadoop/ex0-wordcount/driver.py
