### PR TITLE
Fixed a bug in finding the streaming jar file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ play/*.tb
 hadoopy/thirdparty/pyinstaller/config.dat
 build/
 tests/frozen
+dist/
+hadoopy.egg-info/

--- a/hadoopy/_runner.py
+++ b/hadoopy/_runner.py
@@ -52,7 +52,7 @@ def _find_hstreaming():
         search_root = os.environ['HADOOP_HOME']
     except KeyError:
         search_root = '/'
-    cmd = 'find %s -name hadoop*streaming*.jar' % (search_root)
+    cmd = 'find %s -regex .*/hadoop\-streaming\-[0-9\.]*\.jar' % (search_root)
     p = subprocess.Popen(cmd.split(), stdout=subprocess.PIPE,
                          stderr=subprocess.PIPE)
     HADOOP_STREAMING_PATH_CACHE = p.communicate()[0].split('\n')[0]


### PR DESCRIPTION
The find command to find the Hadoop streaming jar file gets mixed up when there are source files in Hadoop folders, eg. the following:

```
hadoop-2.6.0/share/hadoop/tools/lib/hadoop-streaming-2.6.0.jar
hadoop-2.6.0/share/hadoop/tools/sources/hadoop-streaming-2.6.0-sources.jar
hadoop-2.6.0/share/hadoop/tools/sources/hadoop-streaming-2.6.0-test-sources.jar
```
