### PR TITLE
Fix github link

### DIFF
--- a/doc/tutorial.rst
+++ b/doc/tutorial.rst
@@ -17,7 +17,7 @@ PIP installation ::
 
     sudo pip install -e git+https://github.com/bwhite/hadoopy#egg=hadoopy
 
-.. _github: http://github github.com/bwhite/hadoopy
+.. _github: http://github.com/bwhite/hadoopy
 
 This guide assumes you have a functional Hadoop cluster with a supported version of Hadoop.  If you need help with this see the :doc:`cluster guide</clustersetup>`
 


### PR DESCRIPTION
The tutorial is actually pointing to: http://githubgithub.com/bwhite/hadoopy, which is not the correct URL.
